### PR TITLE
Fix panic for dual-stack network as path endpoint in print-path

### DIFF
--- a/go/pkg/pass1/print-path.go
+++ b/go/pkg/pass1/print-path.go
@@ -80,6 +80,13 @@ func (c *spoc) printPath(stdout io.Writer, path string, params []string) {
 			c.abort("Unsupported element: %v", elements[0])
 		}
 	}
+	// If one side is a dual-stack (combined46) network, pick the part
+	// that matches the IP version of the other side.
+	for i := range l {
+		if l[i].isCombined46() && l[i].isIPv6() != l[1-i].isIPv6() {
+			l[i] = l[i].combined46
+		}
+	}
 
 	znl := make(map[*zone]netList)
 	isUsed := make(map[string]bool)

--- a/go/testdata/print-path/print-path.t
+++ b/go/testdata/print-path/print-path.t
@@ -146,3 +146,22 @@ network:n2 = { ip = 10.1.2.0/24; }
 network:n3 = { ip = 10.1.3.0/24; }
 =OUTPUT=
 ["network:n1","network:n2","network:n3","router:r1","router:u1"]
+=END=
+
+############################################################
+=TITLE=Path from dual stack network to v6 network
+=PARAMS=network:n1 network:n2
+=INPUT=
+router:r1 = {
+ managed;
+ model = ASA;
+ interface:n1 = { ip = 10.1.1.1; ip6 = 2001:db8:1:1::1; hardware = n1; }
+ interface:n2 = { ip6 = 2001:db8:9:2::1; hardware = n2; }
+}
+
+network:n1 = { ip = 10.1.1.0/24; ip6 = 2001:db8:1:1::/64; }
+network:n2 = { ip6 = 2001:db8:9:2::/64; }
+
+=OUTPUT=
+["network:n1","network:n2","router:r1"]
+=END=


### PR DESCRIPTION
When a dual-stack network is given as endpoint, expandGroup returns both IPv4 and IPv6 halves. The code always picked elements[0] (IPv4), causing a nil pointer panic when the other endpoint was IPv6-only. Fix: after both endpoints are known, swap to the matching IP version via combined46.